### PR TITLE
More flexible caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,19 @@ Works out of the box for most backgrounds, but ImageMagick must be installed to 
 
 Note: GNOME Settings currently has an issue of it 'resetting' the accent colour when the Appearance page is open and the accent colour is changed externally.
 To avoid this, navigate away from the Appearance page (or close the Settings window), and re-run the Auto Accent Colour script by clicking the 'Force Refresh' indicator option, disabling/re-enabling the extension, or locking and unlocking your device.
+
+## Development
+Get the source:
+```
+mkdir -p ~/.local/share/gnome-shell/extensions
+cd !$
+git clone https://github.com/Wartybix/GNOME-Auto-Accent-Colour auto-accent-colour@Wartybix
+cd !$
+```
+
+Recompile schemas:
+```
+glib-compile-schemas ./schemas
+```
+
+Then, either restart or create a nested gnome shell; see [](https://gjs.guide/extensions/development/creating.html#testing-the-extension).

--- a/cache.js
+++ b/cache.js
@@ -1,0 +1,66 @@
+import Gio from 'gi://Gio'
+import GLib from 'gi://GLib'
+
+import { journal } from './utils.js'
+
+function getExtensionCacheDir() {
+    return `${GLib.get_home_dir()}/.cache/auto-accent-colour`
+}
+
+// fake cache that does nothing
+// serves as an interface reference
+// but can also be used to disable caching
+// (also ya... i can do oop js... for sure...)
+function noCache() {
+    function get(key) { return null; }
+    function set(key, data) { }
+    // function delete ...
+    // function clear ...
+    return { get: get, set: set };
+}
+
+// simple file-based cache
+// TODO: make it async? I'm not great at this and the docs seem a little off?
+function fileBasedCache(cachedir) {
+    function _setup() {
+        journal(`Ensuring cache directory ${cachedir} exists...`);
+        GLib.mkdir_with_parents(cachedir, 0o0755);
+    }
+    function _file(key) {
+        return Gio.File.new_for_path(`${cachedir}/${key}`);
+    }
+    function get(key) {
+        const file = _file(key);
+        if (!file.query_exists(null)) {
+            return null;
+        }
+        journal(`Reading cache entry from ${file.get_path()}...`);
+        const [_ok, contents, _etag] = file.load_contents(null);
+        const decoder = new TextDecoder('utf-8');
+        const contentsString = decoder.decode(contents);
+        try {
+            return JSON.parse(contentsString);
+        } catch (err) {
+            journal(`unable to parse ${file.get_path()}: ${err}`);
+            return null;
+        }
+    }
+    function set(key, data) {
+        const file = _file(key);
+        journal(`Writing cache entry to ${file.get_path()}...`);
+        const cereal = JSON.stringify(data);
+        const bytes = new GLib.Bytes(cereal);
+        const stream = file.replace(null, false, Gio.FileCreateFlags.NONE, null);
+        stream.write_bytes(bytes, null);
+    }
+    // function delete ...
+    // function clear ...
+    _setup();
+    return { get: get, set: set };
+}
+
+export {
+    getExtensionCacheDir,
+    noCache,
+    fileBasedCache,
+}

--- a/extension.js
+++ b/extension.js
@@ -451,36 +451,12 @@ export default class AutoAccentColourExtension extends Extension {
             return interfaceSettings.get_string('gtk-theme')
         }
 
-        function getIgnoreCaches() {
-            return extensionSettings.get_boolean('ignore-caches')
+        function getDisableCache() {
+            return extensionSettings.get_boolean('disable-cache')
         }
         function getCache() {
-            return getIgnoreCaches() ? noCache() : fileBasedCache(getExtensionCacheDir())
+            return getDisableCache() ? noCache() : fileBasedCache(getExtensionCacheDir())
         }
-
-        // TODO: remove these then edit schema
-        // function getCachedHash() {
-        //     if (getIgnoreCaches()) {
-        //         return -1
-        //     }
-        //
-        //     return extensionSettings.get_int64(
-        //         getColorScheme() === PREFER_DARK ? 'dark-hash' : 'light-hash'
-        //     )
-        // }
-        // function getCachedLastChange() {
-        //     return extensionSettings.get_int64(
-        //         getColorScheme() === PREFER_DARK ? 'dark-last-change' : 'light-last-change'
-        //     )
-        // }
-        // function getCachedAccent() {
-        //     const theme = getColorScheme() === PREFER_DARK ? 'dark' : 'light'
-        //     const colourMode = extensionSettings.get_boolean('highlight-mode')
-        //         ? 'highlight'
-        //         : 'dominant'
-        //
-        //     return extensionSettings.get_enum(`${theme}-${colourMode}-accent`)
-        // }
 
         function getKeepConversion() {
             return extensionSettings.get_boolean('keep-conversion')

--- a/extension.js
+++ b/extension.js
@@ -309,27 +309,12 @@ async function applyClosestAccent(
         clearConvertedBackground()
     }
 
-    // TODO: avoid redundant computation here?
+    const accentType = highlightMode ? 'highlight' : 'dominant';
+    const paletteIndex = highlightMode ? 1 : 0;
+    const [r, g, b] = backgroundPalette[paletteIndex];
 
-    journal('Getting dominant accent...')
-    const [dom_r, dom_g, dom_b] = backgroundPalette[0] // Dominant RGB value
-    const dom_accent = getClosestAccentColour(
-        accentColours,
-        dom_r,
-        dom_g,
-        dom_b
-    ) // Dominant accent
-
-    journal('Getting highlight accent...')
-    const [hi_r, hi_g, hi_b] = backgroundPalette[1] // Highlight RGB value
-    const hi_accent = getClosestAccentColour(
-        accentColours,
-        hi_r,
-        hi_g,
-        hi_b
-    ) // Highlight accent
-
-    const closestAccentIndex = highlightMode ? hi_accent : dom_accent
+    journal(`Getting ${accentType} accent...`)
+    const closestAccentIndex = getClosestAccentColour(accentColours, r, g, b)
     const closestAccent = accentColours[closestAccentIndex]
 
     journal(`Accent to apply: ${closestAccent.name}`)
@@ -492,9 +477,7 @@ export default class AutoAccentColourExtension extends Extension {
             function set(key, data) {
                 const file = _file(key);
                 journal(`Writing cache entry to ${file.get_path()}...`);
-                journal(`${data}`);
                 const cereal = JSON.stringify(data);
-                journal(`${cereal}`);
                 const bytes = new GLib.Bytes(cereal);
                 const stream = file.replace(null, false, Gio.FileCreateFlags.NONE, null);
                 stream.write_bytes(bytes, null);

--- a/extension.js
+++ b/extension.js
@@ -164,25 +164,23 @@ async function clearConvertedBackground() {
 
 async function convert(imagePath) {
     const cacheDirPath = getExtensionCacheDir()
+    GLib.mkdir_with_parents(cacheDirPath, 0o0755)
+
     const convertedPath = `${cacheDirPath}/${CONVERTED_BACKGROUND_FILENAME}`
+    const convertedFile = Gio.File.new_for_path(convertedPath);
 
-    try {
-        GLib.mkdir_with_parents(cacheDirPath, 0o0755)
-
-        if (isImageMagickInstalled()) {
-            journal('Converting via ImageMagick...')
-            await execCommand(['magick', imagePath, convertedPath])
-        } else if (isRsvgConvertAvailable()) {
-            journal('Converting via rsvg-convert...')
-            await execCommand(['sh', '-c', `rsvg-convert ${imagePath} > ${convertedPath}`])
-        } else {
-            return imagePath
-        }
-    } catch (e) {
-        console.error(e)
+    if (isImageMagickInstalled()) {
+        await execCommand(['magick', imagePath, convertedPath])
+    } else if (isRsvgConvertAvailable()) {
+        await execCommand(['rsvg-convert', imagePath, '>', convertedPath])
+    } else {
+        throw new Error(`No conversion methods available!`);
     }
 
-    return convertedPath
+    if (!convertedFile.query_exists(null)) {
+        throw new Error(`Conversion finished but ${convertedFile.get_path()} does not exist!`);
+    }
+    return convertedFile;
 }
 
 /*
@@ -228,118 +226,114 @@ async function applyClosestAccent(
     extensionPath,
     accentColours,
     backgroundUri,
-    cachedHash,
-    cachedLastChangeHash,
-    cachedAccentIndex,
-    addToCache,
+    accentColours,
+    cache,
     highlightMode,
     keepConversion,
     onDependencyFail,
     onXmlDetected,
     onFinish
 ) {
-    journal(`Cached hash: ${cachedHash}`)
-    journal(`Cached last change hash: ${cachedLastChangeHash}`)
-
-    const backgroundFile = Gio.File.new_for_uri(backgroundUri)
-    const backgroundHash = backgroundFile.hash()
-    journal(`File URI: ${backgroundUri}`)
-    journal(`Background hash: ${backgroundHash}`)
-
+    const backgroundFile = Gio.File.new_for_uri(backgroundUri);
     const backgroundFileInfo = await backgroundFile.query_info_async(
         'standard::*,time::*',
         Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
         GLib.PRIORITY_DEFAULT,
         null
     )
+    const backgroundImgFormat = backgroundFileInfo.get_content_type()
 
-    const backgroundLastChange = backgroundFileInfo.get_modification_date_time()
-    journal(`Background last changed: ${backgroundLastChange.format_iso8601()}`)
+    journal(`Background image format: ${backgroundImgFormat}`)
 
-    const backgroundLastChangeHash = backgroundLastChange.hash()
-    journal(`Background last changed hash: ${backgroundLastChangeHash}`)
+    /* suggestion (HM); replace below logic with map of image type to converters (array of functions); e.g.
+     * const converter_map = {
+     *     'image/svg+xml': [magick, rsvg],
+     *     'image/jxl': [magick],
+     *     'application/xml': [panic],
+     * }
+     * const converters = converter_map[backgroundImgFormat]
+     * then loop converters until one works, returning converted fp, or panic (maybe collect errs)
+     */
 
-    if (backgroundHash === cachedHash && backgroundLastChangeHash === cachedLastChangeHash) {
-        const cachedAccent = accentColours[cachedAccentIndex]
-        journal(`Returning cached accent (${cachedAccent.name})`)
-        onFinish(cachedAccent)
-    } else {
-        const backgroundImgFormat = backgroundFileInfo.get_content_type()
-        journal(`Background image format: ${backgroundImgFormat}`)
+    if (backgroundImgFormat === 'application/xml') {
+        onXmlDetected()
+        return
+    }
 
-        if (backgroundImgFormat === 'application/xml') {
-            onXmlDetected()
-            return
-        }
+    /* List of image formats that don't work well with colorthief, and often
+    cause crashes or return incorrect colours as a result, requiring conversion.
+    If you know of any other formats that don't work well with this extension,
+    please submit an issue or pull request. */
+    const incompatibleFormats = ['image/svg+xml', 'image/jxl']
+    const conversionRequired = incompatibleFormats.includes(backgroundImgFormat)
+    journal(`Conversion to JPG required: ${conversionRequired}`)
 
-        /* List of image formats that don't work well with colorthief, and often
-        cause crashes or return incorrect colours as a result, requiring conversion.
-        If you know of any other formats that don't work well with this extension,
-        please submit an issue or pull request. */
-        const incompatibleFormats = ['image/svg+xml', 'image/jxl']
-        const conversionRequired = incompatibleFormats.includes(backgroundImgFormat)
-
-        journal(`Conversion to JPG required: ${conversionRequired}`)
-
-        if (conversionRequired) {
-            if (!isImageMagickInstalled()) {
-                if (backgroundImgFormat === 'image/svg+xml') {
-                    if (!isRsvgConvertAvailable()) {
-                        journal('ImageMagick v7+ not installed nor rsvg-convert available !!')
-                        onDependencyFail()
-                        return
-                    }
-                } else {
-                    journal('ImageMagick v7+ not installed !!')
+    var rasterFile = backgroundFile;
+    if (conversionRequired) {
+        if (!isImageMagickInstalled()) {
+            if (backgroundImgFormat === 'image/svg+xml') {
+                if (!isRsvgConvertAvailable()) {
+                    journal('ImageMagick v7+ not installed nor rsvg-convert available !!')
                     onDependencyFail()
                     return
                 }
+            } else {
+                journal('ImageMagick v7+ not installed !!')
+                onDependencyFail()
+                return
             }
         }
 
-        const backgroundPath = backgroundFile.get_path()
-
-        const rasterPath = conversionRequired
-            ? await convert(backgroundPath)
-            : backgroundPath
-        journal(`Raster path: ${rasterPath}`)
-
-        const backgroundPalette = await getBackgroundPalette(
-            extensionPath,
-            rasterPath
-        )
-
-        if (conversionRequired && !keepConversion) {
-            clearConvertedBackground()
+        try {
+            rasterFile = await convert(backgroundFile.get_path());
+        } catch (err) {
+            console.log(`Failed to convert background: ${err}`);
+            return;
         }
-
-        journal('Getting dominant accent...')
-        const [dom_r, dom_g, dom_b] = backgroundPalette[0] // Dominant RGB value
-        const dom_accent = getClosestAccentColour(
-            accentColours,
-            dom_r,
-            dom_g,
-            dom_b
-        ) // Dominant accent
-
-        journal('Getting highlight accent...')
-        const [hi_r, hi_g, hi_b] = backgroundPalette[1] // Highlight RGB value
-        const hi_accent = getClosestAccentColour(
-            accentColours,
-            hi_r,
-            hi_g,
-            hi_b
-        ) // Highlight accent
-
-        addToCache(backgroundHash, backgroundLastChangeHash, dom_accent, hi_accent)
-
-        const closestAccentIndex = highlightMode ? hi_accent : dom_accent
-        const closestAccent = accentColours[closestAccentIndex]
-
-        journal(`Accent to apply: ${closestAccent.name}`)
-
-        onFinish(closestAccent)
     }
+
+    // TODO: potentially allow for other hashing methods? e.g. pass cache_keyer func as arg?
+    const [bytes, _] = rasterFile.load_bytes(null);
+    const backgroundHash = bytes.hash();
+    journal(`Hash of background in ${rasterFile.get_path()} is ${backgroundHash}...`);
+    var backgroundPalette = cache.get(backgroundHash)
+    if (backgroundPalette === null) {
+        journal(`Cache miss: recomputing palette...`);
+        const rasterPath = rasterFile.get_path();
+        backgroundPalette = await getBackgroundPalette(extensionPath, rasterPath)
+        cache.set(backgroundHash, backgroundPalette);
+    }
+    journal(`Palette: ${backgroundPalette}...`);
+
+    if (conversionRequired && !keepConversion) {
+        clearConvertedBackground()
+    }
+
+    // TODO: avoid redundant computation here?
+
+    journal('Getting dominant accent...')
+    const [dom_r, dom_g, dom_b] = backgroundPalette[0] // Dominant RGB value
+    const dom_accent = getClosestAccentColour(
+        accentColours,
+        dom_r,
+        dom_g,
+        dom_b
+    ) // Dominant accent
+
+    journal('Getting highlight accent...')
+    const [hi_r, hi_g, hi_b] = backgroundPalette[1] // Highlight RGB value
+    const hi_accent = getClosestAccentColour(
+        accentColours,
+        hi_r,
+        hi_g,
+        hi_b
+    ) // Highlight accent
+
+    const closestAccentIndex = highlightMode ? hi_accent : dom_accent
+    const closestAccent = accentColours[closestAccentIndex]
+
+    journal(`Accent to apply: ${closestAccent.name}`)
+    onFinish(closestAccent)
 }
 
 export default class AutoAccentColourExtension extends Extension {
@@ -420,47 +414,95 @@ export default class AutoAccentColourExtension extends Extension {
             return interfaceSettings.get_string('gtk-theme')
         }
 
+        // TODO: this can be replaced by using a dummy cache interface instead
         function getIgnoreCaches() {
             return extensionSettings.get_boolean('ignore-caches')
         }
-        function getCachedHash() {
-            if (getIgnoreCaches()) {
-                return -1
-            }
 
-            return extensionSettings.get_int64(
-                getColorScheme() === PREFER_DARK ? 'dark-hash' : 'light-hash'
-            )
-        }
-        function getCachedLastChange() {
-            return extensionSettings.get_int64(
-                getColorScheme() === PREFER_DARK ? 'dark-last-change' : 'light-last-change'
-            )
-        }
-        function getCachedAccent() {
-            const theme = getColorScheme() === PREFER_DARK ? 'dark' : 'light'
-            const colourMode = extensionSettings.get_boolean('highlight-mode')
-                ? 'highlight'
-                : 'dominant'
+        // TODO: remove these here and in schema?
+        // function getCachedHash() {
+        //     if (getIgnoreCaches()) {
+        //         return -1
+        //     }
+        //
+        //     return extensionSettings.get_int64(
+        //         getColorScheme() === PREFER_DARK ? 'dark-hash' : 'light-hash'
+        //     )
+        // }
+        // function getCachedLastChange() {
+        //     return extensionSettings.get_int64(
+        //         getColorScheme() === PREFER_DARK ? 'dark-last-change' : 'light-last-change'
+        //     )
+        // }
+        // function getCachedAccent() {
+        //     const theme = getColorScheme() === PREFER_DARK ? 'dark' : 'light'
+        //     const colourMode = extensionSettings.get_boolean('highlight-mode')
+        //         ? 'highlight'
+        //         : 'dominant'
+        //
+        //     return extensionSettings.get_enum(`${theme}-${colourMode}-accent`)
+        // }
 
-            return extensionSettings.get_enum(`${theme}-${colourMode}-accent`)
-        }
         function getKeepConversion() {
             return extensionSettings.get_boolean('keep-conversion')
         }
 
-        function cache(backgroundHash, lastChange, dominantAccent, highlightAccent) {
-            const currentTheme = getColorScheme() === PREFER_DARK ? 'dark' : 'light'
-            const backgroundsAreSame = getBackgroundUri() === getDarkBackgroundUri()
+        // function cache(backgroundHash, lastChange, dominantAccent, highlightAccent) {
+        //     const currentTheme = getColorScheme() === PREFER_DARK ? 'dark' : 'light'
+        //     const backgroundsAreSame = getBackgroundUri() === getDarkBackgroundUri()
+        //
+        //     for (const theme of ['dark', 'light']) {
+        //         if (currentTheme === theme || backgroundsAreSame) {
+        //             extensionSettings.set_int64(`${theme}-hash`, backgroundHash)
+        //             extensionSettings.set_int64(`${theme}-last-change`, lastChange)
+        //             extensionSettings.set_enum(`${theme}-dominant-accent`, dominantAccent)
+        //             extensionSettings.set_enum(`${theme}-highlight-accent`, highlightAccent)
+        //         }
+        //     }
+        // }
 
-            for (const theme of ['dark', 'light']) {
-                if (currentTheme === theme || backgroundsAreSame) {
-                    extensionSettings.set_int64(`${theme}-hash`, backgroundHash)
-                    extensionSettings.set_int64(`${theme}-last-change`, lastChange)
-                    extensionSettings.set_enum(`${theme}-dominant-accent`, dominantAccent)
-                    extensionSettings.set_enum(`${theme}-highlight-accent`, highlightAccent)
+        // cache interface
+        // simple file-based cache
+        // TODO: async?
+        // (ya... i can do oop js... for sure...)
+        function cache(cachedir) {
+            function _setup() {
+                journal(`Ensuring cache directory ${cachedir} exists...`);
+                GLib.mkdir_with_parents(cachedir, 0o0755);
+            }
+            function _file(key) {
+                return Gio.File.new_for_path(`${cachedir}/${key}`);
+            }
+            function get(key) {
+                const file = _file(key);
+                if (!file.query_exists(null)) {
+                    return null;
+                }
+                journal(`Reading cache entry from ${file.get_path()}...`);
+                const [_ok, contents, _etag] = file.load_contents(null);
+                const decoder = new TextDecoder('utf-8');
+                const contentsString = decoder.decode(contents);
+                try {
+                    return JSON.parse(contentsString);
+                } catch (err) {
+                    journal(`unable to parse ${file.get_path()}: ${err}`);
+                    return null;
                 }
             }
+            function set(key, data) {
+                const file = _file(key);
+                journal(`Writing cache entry to ${file.get_path()}...`);
+                journal(`${data}`);
+                const cereal = JSON.stringify(data);
+                journal(`${cereal}`);
+                const bytes = new GLib.Bytes(cereal);
+                const stream = file.replace(null, false, Gio.FileCreateFlags.NONE, null);
+                stream.write_bytes(bytes, null);
+            }
+            // function delete ...
+            // function clear ...
+            _setup();
+            return { get: get, set: set };
         }
 
         function applyYaruTheme() {
@@ -568,6 +610,7 @@ export default class AutoAccentColourExtension extends Extension {
 
         function setAccent() {
             if (running) {
+                journal(`Already running...`)
                 return
             }
 
@@ -585,10 +628,8 @@ export default class AutoAccentColourExtension extends Extension {
                 extensionPath,
                 accentColours,
                 backgroundUri,
-                getCachedHash(),
-                getCachedLastChange(),
-                getCachedAccent(),
-                cache,
+                accentColours,
+                cache(getExtensionCacheDir()),
                 highlightMode,
                 getKeepConversion(),
                 function() {

--- a/prefs.js
+++ b/prefs.js
@@ -182,8 +182,7 @@ is cached to increase performance.'
 
         const disableCacheRow = new Adw.SwitchRow({
             title: _('Disable Cache'),
-            subtitle: _("Always parse colours from the background, even if accent \
-colours from a given background have already been derived and cached.")
+            subtitle: _("Always parse colours from the background, even if the palette for a given background is in the cache. Do not cache computed palettes.")
         })
         cacheGroup.add(disableCacheRow)
 

--- a/schemas/org.gnome.shell.extensions.auto-accent-colour.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.auto-accent-colour.gschema.xml
@@ -25,31 +25,13 @@
     <key name="keep-conversion" type="b">
       <default>false</default>
     </key>
-    <key name="ignore-caches" type="b">
+    <key name="disable-cache" type="b">
       <default>false</default>
-    </key>
-    <key name="light-hash" type="x">
-      <default>-1</default>
-    </key>
-    <key name="light-last-change" type="x">
-      <default>-1</default>
     </key>
     <key name="light-dominant-accent" enum="org.gnome.shell.extensions.auto-accent-colour.accents">
       <default>'blue'</default>
     </key>
     <key name="light-highlight-accent" enum="org.gnome.shell.extensions.auto-accent-colour.accents">
-      <default>'blue'</default>
-    </key>
-    <key name="dark-hash" type="x">
-      <default>-1</default>
-    </key>
-    <key name="dark-last-change" type="x">
-      <default>-1</default>
-    </key>
-    <key name="dark-dominant-accent" enum="org.gnome.shell.extensions.auto-accent-colour.accents">
-      <default>'blue'</default>
-    </key>
-    <key name="dark-highlight-accent" enum="org.gnome.shell.extensions.auto-accent-colour.accents">
       <default>'blue'</default>
     </key>
   </schema>


### PR DESCRIPTION
resolves #11

Replace the previous single background fileobj hash caching method with a cache that uses the hash of the image contents as keys.

`applyClosestAccentColour` now just takes a cache object, which is expected to have a fairly standard get/set interface and is used to lru cache the output of the palette computation.

the `noCache` and `fileBasedCache` both implement that interface. Which to uses is determined by the disable cache gsettings value. There is also an option in the extension settings to clear the cache.

As far as I can tell it seems pretty stable-ish, and clears up some verbose logic regarding the light and dark themes (provided that last git rebase didn't add any sneaky bits I didn't catch). Potential improvements are:
- linting (I don't have eslint or whatever it is set up :( )
- add a size limit to the cache (deque style)
- or equivalently some kind of cache garbage collection maybe
- do async stuff for the methods on the cache? (idrk know what I'm doing with async)