### PR TITLE
Use GitHub Action to check translation files

### DIFF
--- a/.github/workflows/l10n-check.yml
+++ b/.github/workflows/l10n-check.yml
@@ -1,0 +1,24 @@
+name: Update translations
+
+on:
+    push:
+        branches: [ 'main' ]
+    pull_request:
+      branches: [ 'main' ]
+
+jobs:
+  run-update-translations:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install gettext
+        run: sudo apt-get update && sudo apt-get install -y gettext
+
+      - name: Make script executable
+        run: chmod +x ./update-translations.sh
+
+      - name: Run update-translations script
+        run: ./update-translations.sh

--- a/update-translations.sh
+++ b/update-translations.sh
@@ -12,8 +12,13 @@ xgettext --msgid-bugs-address="34974060+Wartybix@users.noreply.github.com" \
          --output="$POTFILE" \
          ./*.js
 
-# Refresh the po files if desired
-read -p "Do you want to refresh the existing translations? [y|N] " -r response
+# Refresh the po files if desired. Do this always when run in a GitHub Action.
+if [ -n "$CI" ]; then
+    response="y"
+else
+    read -p "Do you want to refresh the existing translations? [y|N] " -r response
+fi
+
 if [[ "$response" == "y" || "$response" == "Y" ]]; then
     for file in po/*.po; do
         echo "Refreshing $file..."


### PR DESCRIPTION
While running `update-translations.sh`, I noticed that it produces an error for the Italian translation that was updated in #14.

To prevent shipping `po` files with faulty syntax, I think automated testing would be nice. Running the update script on every push and PR to the main branch should ensure that we get notified if there is some syntax-affecting typo.
What do you think about this?